### PR TITLE
Improve loader performance by adding threading (resolves LOAD-7)

### DIFF
--- a/loader/standard_loader.py
+++ b/loader/standard_loader.py
@@ -5,6 +5,7 @@ import re
 import typing
 
 from loader.base_loader import DssUploader, MetadataFileUploader
+from util import patch_connection_pools
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +186,7 @@ class StandardFormatBundleUploader:
 
     def _load_parsed_bundles_concurrent(self):
         """Loads already parsed bundles concurrently using threads"""
+        patch_connection_pools(maxsize=256)
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = [executor.submit(self._load_bundle_concurrent, count, parsed_bundle)
                        for count, parsed_bundle in enumerate(self.bundles_parsed)]

--- a/loader/standard_loader.py
+++ b/loader/standard_loader.py
@@ -121,9 +121,9 @@ class StandardFormatBundleUploader:
 
         return ParsedBundle(bundle_uuid, metadata_dict, parsed_files)
 
-    def _load_bundle(self, bundle_uuid, metadata_dict, data_files):
+    def _load_bundle(self, bundle_uuid, metadata_dict, data_files, bundle_num):
         """Do the actual loading for an already parsed bundle"""
-        logger.info(f'Attempting to load bundle with uuid {bundle_uuid}')
+        logger.info(f'Bundle {bundle_num}: Attempting to load. UUID: {bundle_uuid}')
         file_info_list = []
 
         # load metadata, ignore whether the file was already present
@@ -132,14 +132,15 @@ class StandardFormatBundleUploader:
                                                   "metadata.json",
                                                   SCHEMA_URL,
                                                   bundle_uuid)
-        logger.debug(f'Uploaded metadata file: {metadata_filename} with '
+        logger.debug(f'Bundle {bundle_num}: Uploaded metadata file: {metadata_filename} with '
                      f'uuid:version {metadata_file_uuid}:{metadata_file_version}')
         file_info_list.append(dict(uuid=metadata_file_uuid, version=metadata_file_version,
                                    name=metadata_filename, indexed=True))
 
         for data_file in data_files:
             filename, file_uuid, cloud_urls, bundle_uuid, file_guid, file_version, = data_file
-            logger.debug(f'Attempting to upload data file: {filename} with uuid:version {file_uuid}:{file_version}...')
+            logger.debug(f'Bundle {bundle_num}: Attempting to upload data file: {filename} '
+                         f'with uuid:version {file_uuid}:{file_version}...')
             file_uuid, file_version, filename, already_present = \
                 self.dss_uploader.upload_cloud_file_by_reference(filename,
                                                                  file_uuid,
@@ -148,8 +149,9 @@ class StandardFormatBundleUploader:
                                                                  file_guid,
                                                                  file_version=file_version)
             if already_present:
-                logger.debug('File already present. No upload necessary.')
-            logger.debug(f'...Successfully uploaded data file: {filename} with uuid:version {file_uuid}:{file_version}')
+                logger.debug('Bundle {bundle_num}: File {filename} already present. No upload necessary.')
+            logger.debug(f'Bundle {bundle_num}: ...Successfully uploaded data file: {filename} '
+                         f'with uuid:version {file_uuid}:{file_version}')
             file_info_list.append(dict(uuid=file_uuid, version=file_version, name=filename, indexed=False))
 
         # load bundle
@@ -165,28 +167,25 @@ class StandardFormatBundleUploader:
                 parsed_bundle = self._parse_bundle(bundle)
                 self.bundles_parsed.append(parsed_bundle)
             except ParseError:
-                logger.exception(f'Could not parse bundle {count + 1}')
+                logger.exception(f'Could not parse bundle {count}')
                 logger.debug(f'Bundle details: \n{pprint.pformat(bundle)}')
                 self.bundles_failed_unparsed.append(bundle)
 
-    def _load_bundle_concurrent(self, count, parsed_bundle, logger=logger):
-        logger.info(f'Attempting to load bundle {count + 1}')
+    def _load_bundle_concurrent(self, count, parsed_bundle):
+        logger.info(f'Bundle {count}: Attempting to load ')
         try:
-            self._load_bundle(*parsed_bundle)
+            self._load_bundle(*parsed_bundle, count)
         except Exception:
-            logger.exception(f'Error loading bundle {parsed_bundle.bundle_uuid}')
-            logger.debug(f'Bundle details: \n{parsed_bundle.pprint()}')
+            logger.exception(f'Bundle {count}: Error loading. ID: {parsed_bundle.bundle_uuid}')
+            logger.debug(f'Bundle {count} details: \n{parsed_bundle.pprint()}')
             self.bundles_failed_parsed.append(parsed_bundle)
             return
         self.bundles_loaded.append(parsed_bundle)
-        logger.info(f'Successfully loaded bundle {parsed_bundle.bundle_uuid}')
+        logger.info(f'Bundle {count}: Successfully loaded. ID: {parsed_bundle.bundle_uuid}')
 
     def _load_parsed_bundles_concurrent(self):
         """Loads already parsed bundles concurrently using threads"""
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            # approach for logging: make a new (indexed) logger for each thread.
-            # give a custom handler that writes to list
-            # as futures finish, log their stuff
             futures = [executor.submit(self._load_bundle_concurrent, count, parsed_bundle)
                        for count, parsed_bundle in enumerate(self.bundles_parsed)]
             concurrent.futures.wait(futures)
@@ -194,9 +193,9 @@ class StandardFormatBundleUploader:
     def _load_parsed_bundles(self):
         """Loads already parsed bundles"""
         for count, parsed_bundle in enumerate(self.bundles_parsed):
-            logger.info(f'Attempting to load bundle {count + 1}')
+            logger.info(f'Attempting to load bundle {count}')
             try:
-                self._load_bundle(*parsed_bundle)
+                self._load_bundle(*parsed_bundle, count)
             except Exception:
                 logger.exception(f'Error loading bundle {parsed_bundle.bundle_uuid}')
                 logger.debug(f'Bundle details: \n{parsed_bundle.pprint()}')

--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -46,7 +46,7 @@ def main(argv=sys.argv[1:]):
     input_format = subparsers.add_parser("standard", help='Standard CGP DSS input file format')
     input_format.add_argument("--json-input-file", metavar="JSON_INPUT_FILE", required=True,
                               help="Path to the standard JSON format input file")
-    input_format.add_argument('-c', '--concurrently', action='store_true', default=False,
+    input_format.add_argument('--linear', action='store_false', default=True,
                               help='Upload bundles concurrently for a big performance boost')
 
     input_format = subparsers.add_parser("gen3", help='University of Chicago Gen3 input file format')
@@ -70,8 +70,8 @@ def main(argv=sys.argv[1:]):
 
     if options.input_format == "standard":
         bundle_uploader = StandardFormatBundleUploader(dss_uploader, metadata_file_uploader)
-        logging.info(f'Uploading {"concurrently" if options.concurrently else "serially"}')
-        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), options.concurrently)
+        logging.info(f'Uploading {"serially" if options.linear else "concurrently"}')
+        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), not options.linear)
     elif options.input_format == "gen3":
         bundle_uploader = Gen3FormatBundleUploader(dss_uploader, metadata_file_uploader)
         return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file))

--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -46,6 +46,9 @@ def main(argv=sys.argv[1:]):
     input_format = subparsers.add_parser("standard", help='Standard CGP DSS input file format')
     input_format.add_argument("--json-input-file", metavar="JSON_INPUT_FILE", required=True,
                               help="Path to the standard JSON format input file")
+    input_format.add_argument('-c', '--concurrently', action='store_true', default=False,
+                              help='Upload bundles concurrently for a big performance boost')
+
     input_format = subparsers.add_parser("gen3", help='University of Chicago Gen3 input file format')
     input_format.add_argument("--json-input-file", metavar="JSON_INPUT_FILE", required=True,
                               help="Path to the Gen3 JSON format input file")
@@ -65,14 +68,12 @@ def main(argv=sys.argv[1:]):
     logging.getLogger(__name__)
     suppress_verbose_logging()
 
-    success_ = False
     if options.input_format == "standard":
         bundle_uploader = StandardFormatBundleUploader(dss_uploader, metadata_file_uploader)
-        success_ = bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file))
+        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), options.concurrently)
     elif options.input_format == "gen3":
         bundle_uploader = Gen3FormatBundleUploader(dss_uploader, metadata_file_uploader)
-        success_ = bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file))
-    return success_
+        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file))
 
 
 if __name__ == '__main__':

--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -46,8 +46,8 @@ def main(argv=sys.argv[1:]):
     input_format = subparsers.add_parser("standard", help='Standard CGP DSS input file format')
     input_format.add_argument("--json-input-file", metavar="JSON_INPUT_FILE", required=True,
                               help="Path to the standard JSON format input file")
-    input_format.add_argument('--linear', action='store_false', default=True,
-                              help='Upload bundles concurrently for a big performance boost')
+    input_format.add_argument('--serial', action='store_false', default=True,
+                              help='Upload bundles serially. This can be useful for debugging')
 
     input_format = subparsers.add_parser("gen3", help='University of Chicago Gen3 input file format')
     input_format.add_argument("--json-input-file", metavar="JSON_INPUT_FILE", required=True,
@@ -70,8 +70,8 @@ def main(argv=sys.argv[1:]):
 
     if options.input_format == "standard":
         bundle_uploader = StandardFormatBundleUploader(dss_uploader, metadata_file_uploader)
-        logging.info(f'Uploading {"serially" if options.linear else "concurrently"}')
-        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), not options.linear)
+        logging.info(f'Uploading {"serially" if options.serial else "concurrently"}')
+        return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), not options.serial)
     elif options.input_format == "gen3":
         bundle_uploader = Gen3FormatBundleUploader(dss_uploader, metadata_file_uploader)
         return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file))

--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -70,6 +70,7 @@ def main(argv=sys.argv[1:]):
 
     if options.input_format == "standard":
         bundle_uploader = StandardFormatBundleUploader(dss_uploader, metadata_file_uploader)
+        logging.info(f'Uploading {"concurrently" if options.concurrently else "serially"}')
         return bundle_uploader.load_all_bundles(load_json_from_file(options.json_input_file), options.concurrently)
     elif options.input_format == "gen3":
         bundle_uploader = Gen3FormatBundleUploader(dss_uploader, metadata_file_uploader)

--- a/tests/test_standard_loader.py
+++ b/tests/test_standard_loader.py
@@ -292,14 +292,14 @@ class TestLoader(AbstractLoaderTest):
     def test_minimal_bundle_in_dss(self):
         """Try and load a minimally formed bundle"""
         min_bundle = self._make_minimal_bundle()
-        self.loader._load_bundle(*min_bundle)
+        self.loader._load_bundle(*min_bundle, 0)
         self._test_bundles_in_dss([min_bundle])
 
     @ignore_resource_warnings
     def test_bigger_bundle_in_dss(self):
         """Test loading a bundle with several files"""
         big_bundle = self._make_minimal_bundle(files=4)
-        self.loader._load_bundle(*big_bundle)
+        self.loader._load_bundle(*big_bundle, 0)
         self._test_bundles_in_dss([big_bundle])
 
     @ignore_resource_warnings
@@ -337,8 +337,8 @@ class TestLoader(AbstractLoaderTest):
         """Make sure a bundle with a invalid URL fails"""
         bundle = self._make_minimal_bundle(parsed=True)
         bundle.data_files[0].cloud_urls[0] = 'https://example.com'
-        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle)
+        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle, 0)
         bundle.data_files[0].cloud_urls[0] = 's3://definatelynotavalidbucketorfile'
-        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle)
+        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle, 1)
         bundle.data_files[0].cloud_urls[0] = 'gs://definatelynotavalidbucketorfile'
-        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle)
+        self.assertRaises(FileURLError, self.loader._load_bundle, *bundle, 2)

--- a/tests/test_standard_loader.py
+++ b/tests/test_standard_loader.py
@@ -252,6 +252,7 @@ class TestLoader(AbstractLoaderTest):
         Try and load a minimally formed bundle.
 
         Even though this is a concurrent test, nothing is actually running concurrently
+        since there is only one bundle
         """
         self._test_loading_bundles_dict([self._make_minimal_bundle(parsed=False)], concurrently=True)
 
@@ -261,6 +262,7 @@ class TestLoader(AbstractLoaderTest):
         Can we load a bundle with no files?
 
         Even though this is a concurrent test, nothing is actually running concurrently
+        since there are no bundles :)
         """
         self._test_loading_bundles_dict([self._make_minimal_bundle(parsed=False, files=0)], concurrently=True)
 

--- a/tests/test_standard_loader_integration.py
+++ b/tests/test_standard_loader_integration.py
@@ -35,8 +35,8 @@ class TestStandardInputFormatLoading(AbstractLoaderTest):
         for bundle in test_json:
             jsonschema.validate(bundle, standard_schema)
 
-    def test_basic_input_format_loading_from_cli(self):
-        self._test_gen3_loading_from_cli(self.test_file, more_args=['--linear'])
+    def test_basic_input_format_loading_from_cli_serial(self):
+        self._test_gen3_loading_from_cli(self.test_file, more_args=['--serial'])
 
     def test_basic_input_format_loading_from_cli_concurrent(self):
         self._test_gen3_loading_from_cli(self.test_file)

--- a/tests/test_standard_loader_integration.py
+++ b/tests/test_standard_loader_integration.py
@@ -36,10 +36,10 @@ class TestStandardInputFormatLoading(AbstractLoaderTest):
             jsonschema.validate(bundle, standard_schema)
 
     def test_basic_input_format_loading_from_cli(self):
-        self._test_gen3_loading_from_cli(self.test_file)
+        self._test_gen3_loading_from_cli(self.test_file, more_args=['--linear'])
 
     def test_basic_input_format_loading_from_cli_concurrent(self):
-        self._test_gen3_loading_from_cli(self.test_file, more_args=['--concurrently'])
+        self._test_gen3_loading_from_cli(self.test_file)
 
     @staticmethod
     @contextmanager

--- a/tests/test_standard_loader_integration.py
+++ b/tests/test_standard_loader_integration.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 import tempfile
 import unittest
 import uuid
@@ -9,15 +8,13 @@ import logging
 from contextlib import contextmanager
 from pathlib import Path
 
-import hca
 import jsonschema
 import requests
 
-from loader import base_loader
 from loader.schemas import standard_schema
 from loader.standard_loader import SCHEMA_URL
 from scripts.cgp_data_loader import main as cgp_data_loader_main
-from tests import eventually, ignore_resource_warnings, message
+from tests import ignore_resource_warnings, message
 from tests.abstract_loader_test import AbstractLoaderTest
 
 logger = logging.getLogger(__name__)

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -12,3 +12,24 @@ def suppress_verbose_logging():
         if (logger_name.startswith("botocore") or
                 logger_name.startswith("boto3.resources")):
             logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+
+def patch_connection_pools(**constructor_kwargs):
+    """
+    Increase pool size used by requests. Useful for when threading
+
+    adapted from https://stackoverflow.com/a/22253656/7830612
+    """
+    from urllib3 import connectionpool, poolmanager
+
+    class MyHTTPConnectionPool(connectionpool.HTTPConnectionPool):
+        def __init__(self, *args, **kwargs):
+            kwargs.update(constructor_kwargs)
+            super(MyHTTPConnectionPool, self).__init__(*args, **kwargs)
+    poolmanager.pool_classes_by_scheme['http'] = MyHTTPConnectionPool
+
+    class MyHTTPSConnectionPool(connectionpool.HTTPSConnectionPool):
+        def __init__(self, *args, **kwargs):
+            kwargs.update(constructor_kwargs)
+            super(MyHTTPSConnectionPool, self).__init__(*args, **kwargs)
+    poolmanager.pool_classes_by_scheme['https'] = MyHTTPSConnectionPool


### PR DESCRIPTION
This adds a command line argument `-c` or `--concurrently` that will do loading with multiple threads.

What's new:
- a commandline arg for concurrency
- tests for concurrency

Could use input:
- How many threads? should there be a command line option to specify?
  > it will default to the number of processors on the machine, multiplied by 5

  according to the [docs](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor).

- should we default to concurrency (not the case currently)?

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-38)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-38
