### PR TITLE
Update loader to work with whitelisted dss (resolves STOR-2)

### DIFF
--- a/loader/base_loader.py
+++ b/loader/base_loader.py
@@ -76,8 +76,14 @@ class DssUploader:
         self.s3_client = boto3.client("s3")
         self.s3_blobstore = s3.S3BlobStore(self.s3_client)
         self.gs_client = Client()
+
+        # Work around problems with DSSClient initialization when there is
+        # existing HCA configuration. The following issue has been submitted:
+        # Problems accessing an alternate DSS from user scripts or unit tests #170
+        # https://github.com/HumanCellAtlas/dcp-cli/issues/170
         monkey_patch_hca_config()
-        dss_config = HCAConfig(name='loader')
+        HCAConfig._user_config_home = '/tmp/'
+        dss_config = HCAConfig(name='loader', save_on_exit=False, autosave=False)
         dss_config['DSSClient'].swagger_url = f'{self.dss_endpoint}/swagger.json'
         self.dss_client = DSSClient(config=dss_config)
 

--- a/loader/base_loader.py
+++ b/loader/base_loader.py
@@ -37,7 +37,7 @@ from hca import HCAConfig
 from hca.dss import DSSClient
 from hca.util import SwaggerAPIException
 
-from util import tz_utc_now
+from util import tz_utc_now, monkey_patch_hca_config
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,8 @@ class DssUploader:
         self.s3_client = boto3.client("s3")
         self.s3_blobstore = s3.S3BlobStore(self.s3_client)
         self.gs_client = Client()
-        dss_config = HCAConfig()
+        monkey_patch_hca_config()
+        dss_config = HCAConfig(name='loader')
         dss_config['DSSClient'].swagger_url = f'{self.dss_endpoint}/swagger.json'
         self.dss_client = DSSClient(config=dss_config)
 

--- a/tests/abstract_loader_test.py
+++ b/tests/abstract_loader_test.py
@@ -9,6 +9,7 @@ import hca
 
 from scripts.cgp_data_loader import main as cgp_data_loader_main
 from tests import eventually
+from util import monkey_patch_hca_config
 
 TEST_DATA_PATH = Path(__file__).parents[1] / 'tests' / 'test_data'
 
@@ -20,7 +21,8 @@ class AbstractLoaderTest(unittest.TestCase):
         super().setUpClass()
         cls.dss_endpoint = os.getenv("TEST_DSS_ENDPOINT", "https://hca-dss-4.ucsc-cgp-dev.org/v1")
         cls.staging_bucket = os.getenv('DSS_S3_STAGING_BUCKET', 'commons-dss-upload')
-        dss_config = hca.HCAConfig()
+        monkey_patch_hca_config()
+        dss_config = hca.HCAConfig(name='loader-test')
         dss_config['DSSClient'].swagger_url = f'{cls.dss_endpoint}/swagger.json'
         cls.dss_client = hca.dss.DSSClient(config=dss_config)
 

--- a/tests/abstract_loader_test.py
+++ b/tests/abstract_loader_test.py
@@ -5,7 +5,8 @@ import unittest
 from contextlib import contextmanager
 from pathlib import Path
 
-import hca
+from hca import HCAConfig
+from hca.dss import DSSClient
 
 from scripts.cgp_data_loader import main as cgp_data_loader_main
 from tests import eventually
@@ -21,10 +22,16 @@ class AbstractLoaderTest(unittest.TestCase):
         super().setUpClass()
         cls.dss_endpoint = os.getenv("TEST_DSS_ENDPOINT", "https://hca-dss-4.ucsc-cgp-dev.org/v1")
         cls.staging_bucket = os.getenv('DSS_S3_STAGING_BUCKET', 'commons-dss-upload')
+
+        # Work around problems with DSSClient initialization when there is
+        # existing HCA configuration. The following issue has been submitted:
+        # Problems accessing an alternate DSS from user scripts or unit tests #170
+        # https://github.com/HumanCellAtlas/dcp-cli/issues/170
         monkey_patch_hca_config()
-        dss_config = hca.HCAConfig(name='loader-test')
+        HCAConfig._user_config_home = '/tmp/'
+        dss_config = HCAConfig(name='loader-test', save_on_exit=False, autosave=False)
         dss_config['DSSClient'].swagger_url = f'{cls.dss_endpoint}/swagger.json'
-        cls.dss_client = hca.dss.DSSClient(config=dss_config)
+        cls.dss_client = DSSClient(config=dss_config)
 
     @eventually(timeout_seconds=5.0, retry_interval_seconds=1.0)
     def _search_for_bundle(self, bundle_uuid):

--- a/tests/test_standard_loader_integration.py
+++ b/tests/test_standard_loader_integration.py
@@ -135,10 +135,10 @@ class TestStandardInputFormatLoading(AbstractLoaderTest):
             message("Verify that all of the results (except metadata.json) are file references "
                     "and set to not be indexed")
             found_matching_file = False
-            for r in search_results['results']:
-                response = requests.get(r['bundle_url'])
-                returned_json = response.json()
-                for f in returned_json['bundle']['files']:
+            for result in search_results['results']:
+                bundle_uuid, _, bundle_version = result['bundle_fqid'].partition(".")
+                bundle_manifest = self.dss_client.get_bundle(replica="aws", uuid=bundle_uuid, version=bundle_version)
+                for f in bundle_manifest['bundle']['files']:
                     if f['name'] != 'metadata.json':
                         assert f['indexed'] is False
                         assert 'dss-type=fileref' in f['content-type']

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+from hca import HCAConfig
 
 
 def load_json_from_file(input_file_path: str):
@@ -44,3 +45,5 @@ def utc_now():
     return datetime.datetime.utcnow().isoformat()
 
 
+def monkey_patch_hca_config():
+    HCAConfig.__init__ = HCAConfig.__bases__[0].__init__


### PR DESCRIPTION
This *should* have just worked out of the box without this PR but there were some bugs to resolve.

### bug 1.
The integration tests used the requests library to get some stuff. Once things become whitelisted and authenticated this becomes a problem. The fix was easy, just use the dss stuff so it all happens correctly behind the scene.

### bug 2.
The way the dss config was initialized caused some problems. The config remembers your setup from before and will automatically pull configurations depending on the name of the config. [`HCAConfig`](https://github.com/HumanCellAtlas/dcp-cli/blob/master/hca/config.py) forced the name to always be "hca" which meant that if ever you had run the command before (no matter when you called `HCAConfig()` things would already be initialized in an "hca"-y way and it would be unable to point to any other dss instance.

The easy solution---you say---just initialize with name not as "hca", [like this](https://github.com/DataBiosphere/cgp-dss-data-loader/commit/58add952296603b741b7585c63279b9eaa03af6d#diff-97306b10ea332a3669f64a09073cbdc3R80). It's a great idea, but the [`HCAConfig`](https://github.com/HumanCellAtlas/dcp-cli/blob/master/hca/config.py) code is written in such a way that doing this causes an error. the culpret is [line 9](https://github.com/HumanCellAtlas/dcp-cli/blob/master/hca/config.py#L9) where `name` is passed to `super()__init__` preventing us from overwriting it later down the inheritance tree.

To work around this I did a very hacky monkey patch to prevent setting this default `name="hca"`. This works great for our purposes; any previous "hca" configs are left untouched if the user had made some before, and we make fresh ones for ourselves.

Fixes #29, #35

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-42)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-42
