### PR TITLE
Fix loader to load in parallel by default (resolves #40)

### DIFF
--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -35,7 +35,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument("-l", "--log", dest="log_level",
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                         default="INFO", help="Set the logging level")
-    parser.add_argument('--serial', action='store_false', default=True,
+    parser.add_argument('--serial', action='store_true', default=False,
                         help='Upload bundles serially. This can be useful for debugging')
     parser.add_argument('input_json', metavar='INPUT_JSON',
                         help="Path to the standard JSON format input file")


### PR DESCRIPTION
The truth values are switched, this fixes the logic.

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-46)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-46
