### PR TITLE
Remove obsolete file reference to bundle UUID (resolves #42)

### DIFF
--- a/loader/standard_loader.py
+++ b/loader/standard_loader.py
@@ -22,7 +22,6 @@ class ParsedDataFile(typing.NamedTuple):
     filename: str
     file_uuid: str
     cloud_urls: typing.List[str]  # list of urls
-    bundle_uuid: str
     file_guid: str
     file_version: str  # rfc3339
 
@@ -117,7 +116,7 @@ class StandardFormatBundleUploader:
             file_uuid = cls._get_file_uuid(file_guid)
             file_version = cls._get_file_version(file_info)
             cloud_urls = cls._get_cloud_urls(file_info)
-            parsed_file = ParsedDataFile(filename, file_uuid, cloud_urls, bundle_uuid, file_guid, file_version)
+            parsed_file = ParsedDataFile(filename, file_uuid, cloud_urls, file_guid, file_version)
             parsed_files.append(parsed_file)
 
         return ParsedBundle(bundle_uuid, metadata_dict, parsed_files)
@@ -132,7 +131,6 @@ class StandardFormatBundleUploader:
             self.metadata_file_uploader.load_dict(metadata_dict,
                                                   "metadata.json",
                                                   SCHEMA_URL,
-                                                  bundle_uuid,
                                                   # just use current time since there is no better source :/
                                                   file_version=tz_utc_now())
         logger.debug(f'Bundle {bundle_num}: Uploaded metadata file: {metadata_filename} with '
@@ -141,14 +139,13 @@ class StandardFormatBundleUploader:
                                    name=metadata_filename, indexed=True))
 
         for data_file in data_files:
-            filename, file_uuid, cloud_urls, bundle_uuid, file_guid, file_version, = data_file
+            filename, file_uuid, cloud_urls, file_guid, file_version, = data_file
             logger.debug(f'Bundle {bundle_num}: Attempting to upload data file: {filename} '
                          f'with uuid:version {file_uuid}:{file_version}...')
             file_uuid, file_version, filename, already_present = \
                 self.dss_uploader.upload_cloud_file_by_reference(filename,
                                                                  file_uuid,
                                                                  cloud_urls,
-                                                                 bundle_uuid,
                                                                  file_guid,
                                                                  file_version=file_version)
             if already_present:

--- a/tests/test_standard_loader.py
+++ b/tests/test_standard_loader.py
@@ -194,13 +194,13 @@ class TestLoader(AbstractLoaderTest):
             file.Acl().put(ACL='public-read')
 
             data_objects[file_guid] = ParsedDataFile(filename, file_uuid, cloud_urls,
-                                                     bundle_uuid, file_guid, file_version)
+                                                     file_guid, file_version)
 
         if parsed:
             return ParsedBundle(bundle_uuid, metadata_dict, list(data_objects.values()))
         else:
             dict_objects = {}
-            for filename, file_uuid, cloud_urls, bundle_uuid, file_guid, file_version in data_objects.values():
+            for filename, file_uuid, cloud_urls, file_guid, file_version in data_objects.values():
                 dict_objects[file_guid] = {
                     'name': filename,
                     'created': file_version,
@@ -305,13 +305,12 @@ class TestLoader(AbstractLoaderTest):
         """
         _, _, data_files = self._make_minimal_bundle()
         data_file = data_files[0]
-        filename, file_uuid, cloud_urls, bundle_uuid, file_guid, file_version, = data_file
+        filename, file_uuid, cloud_urls, file_guid, file_version, = data_file
 
         _, _, _, already_present = \
             self.dss_uploader.upload_cloud_file_by_reference(filename,
                                                              file_uuid,
                                                              cloud_urls,
-                                                             bundle_uuid,
                                                              file_guid,
                                                              file_version=file_version)
         # make sure the file hasn't already been uploaded
@@ -320,7 +319,6 @@ class TestLoader(AbstractLoaderTest):
             self.dss_uploader.upload_cloud_file_by_reference(filename,
                                                              file_uuid,
                                                              cloud_urls,
-                                                             bundle_uuid,
                                                              file_guid,
                                                              file_version=file_version)
         # make sure the file HAS already been uploaded


### PR DESCRIPTION
The DSS used to require that when putting a file into the DSS,
the PUT payload contain the bundle uuid of the bundle the file would be put into.
The DSS no longer requires this, and the loader code has been updated accordingly
 to keep it current with the DSS API.

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-48)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-48
