### PR TITLE
Accomodate inaccessible cloud URLs when loading data by reference ( resolves #44)

### DIFF
--- a/loader/standard_loader.py
+++ b/loader/standard_loader.py
@@ -22,6 +22,7 @@ class ParsedDataFile(typing.NamedTuple):
     filename: str
     file_uuid: str
     cloud_urls: typing.List[str]  # list of urls
+    size: int
     file_guid: str
     file_version: str  # rfc3339
 
@@ -95,6 +96,14 @@ class StandardFormatBundleUploader:
                 raise ParseError(f"Expected 'url' as key for urls in file_info: \n{file_info}")
         return [url_dict['url'] for url_dict in urls]
 
+    @staticmethod
+    def _get_file_size(file_info: dict):
+        if 'size' not in file_info:
+            raise ParseError(f'Size field not present in file_info: \n{file_info}')
+        if not int(file_info['size']) >= 0:
+            raise ParseError(f'Invalid value for size in file_info: \n{file_info}')
+        return file_info['size']
+
     @classmethod
     def _parse_bundle(cls, bundle: dict) -> ParsedBundle:
         try:
@@ -116,7 +125,8 @@ class StandardFormatBundleUploader:
             file_uuid = cls._get_file_uuid(file_guid)
             file_version = cls._get_file_version(file_info)
             cloud_urls = cls._get_cloud_urls(file_info)
-            parsed_file = ParsedDataFile(filename, file_uuid, cloud_urls, file_guid, file_version)
+            file_size = cls._get_file_size(file_info)
+            parsed_file = ParsedDataFile(filename, file_uuid, cloud_urls, file_size, file_guid, file_version)
             parsed_files.append(parsed_file)
 
         return ParsedBundle(bundle_uuid, metadata_dict, parsed_files)
@@ -139,13 +149,14 @@ class StandardFormatBundleUploader:
                                    name=metadata_filename, indexed=True))
 
         for data_file in data_files:
-            filename, file_uuid, cloud_urls, file_guid, file_version, = data_file
+            filename, file_uuid, cloud_urls, file_size, file_guid, file_version = data_file
             logger.debug(f'Bundle {bundle_num}: Attempting to upload data file: {filename} '
                          f'with uuid:version {file_uuid}:{file_version}...')
             file_uuid, file_version, filename, already_present = \
                 self.dss_uploader.upload_cloud_file_by_reference(filename,
                                                                  file_uuid,
                                                                  cloud_urls,
+                                                                 file_size,
                                                                  file_guid,
                                                                  file_version=file_version)
             if already_present:

--- a/scripts/cgp_data_loader.py
+++ b/scripts/cgp_data_loader.py
@@ -56,6 +56,13 @@ def main(argv=sys.argv[1:]):
     logging.getLogger(__name__)
     suppress_verbose_logging()
 
+    if not sys.warnoptions:
+        import warnings
+        # Log each unique cloud URL access warning once by default.
+        # This can be overridden using the "PYTHONWARNINGS" environment variable.
+        # See: https://docs.python.org/3/library/warnings.html
+        warnings.simplefilter('default', 'CloudUrlAccessWarning', append=True)
+
     bundle_uploader = StandardFormatBundleUploader(dss_uploader, metadata_file_uploader)
     logging.info(f'Uploading {"serially" if options.serial else "concurrently"}')
     return bundle_uploader.load_all_bundles(load_json_from_file(options.input_json), not options.serial)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
                       'dcplib >= 1.3.2, < 2',
                       'google-cloud-storage >= 1.9.0, < 2',
                       'hca == 4.1.4',
+                      'iso8601 == 0.1.12',
                       'requests >= 2.18.4, < 3'],
     license='Apache License 2.0',
     include_package_data=True,

--- a/tests/abstract_loader_test.py
+++ b/tests/abstract_loader_test.py
@@ -17,6 +17,8 @@ TEST_DATA_PATH = Path(__file__).parents[1] / 'tests' / 'test_data'
 
 class AbstractLoaderTest(unittest.TestCase):
 
+    dss_client: DSSClient
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
When loading data into the DSS, best results are obtained when all the cloud URLs loaded by reference are accessible. This provides the most complete set of file metadata for the files loaded by reference. However, there are times, mainly during development and testing, when that is not the case. Currently, as we load the GTEx data, we have access to the NIH files in Google but not in AWS. The most important file information is included in the loader input data already.
This change enables the loader to run and do a generally adequate job, even when not all the cloud URLs are accessible.

The specific changes are:

- Make use of the data file size from the input data. File size was already a required field for the input schema, but was not be used. Now the input file size is compared to the actual file size of the cloud URLs that are accessible, and discrepancies result in an error loading the bundle.
If no actual cloud URLs are available for the a given data file, the input file size is used.

- Improved warnings when the cloud URLs are not accessible, using the Python warnings feature/library.

- Updated and enhanced unit tests for the above

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-50)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-50
