### PR TITLE
Correct/improve support for the `--dry-run` option (resolves #46)

### DIFF
--- a/tests/abstract_loader_test.py
+++ b/tests/abstract_loader_test.py
@@ -39,7 +39,7 @@ class AbstractLoaderTest(unittest.TestCase):
     def _search_for_bundle(self, bundle_uuid):
         # Search for the bundle uuid in the DSS and make sure it now exists and uploading was successful
         search_results = self.dss_client.post_search(es_query={'query': {'term': {'uuid': bundle_uuid}}}, replica='aws')
-        assert search_results['total_hits'] > 0
+        assert search_results['total_hits'] > 0, 'Not found'
         return search_results
 
     @staticmethod
@@ -58,7 +58,7 @@ class AbstractLoaderTest(unittest.TestCase):
                 json.dump(json_contents, fh)
             yield jsonFile.name
 
-    def _load_file(self, tmp_json):
+    def _load_bundle(self, tmp_json):
         """ run the load script """
         args = ['--no-dry-run',
                 '--dss-endpoint',


### PR DESCRIPTION
The loader --dry-run option is very useful for checking that the many
preconditions for a successful load before actually putting files/bundles into the DSS.
This is especially important because the DSS doesn't currently provide a good way
to clean-up a partial or unsuccessful load.

However, the implementation of --dry-run was in disrepair and needed to be updated/repaired.
Multiple small yet important changes were made, and a unit test was added.

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-52)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-52
