### PR TITLE
Limit concurrent threads to 5 to not overload azul

### DIFF
--- a/loader/standard_loader.py
+++ b/loader/standard_loader.py
@@ -196,8 +196,8 @@ class StandardFormatBundleUploader:
 
     def _load_parsed_bundles_concurrent(self):
         """Loads already parsed bundles concurrently using threads"""
-        patch_connection_pools(maxsize=256)
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        patch_connection_pools(maxsize=64)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             futures = [executor.submit(self._load_bundle_concurrent, count, parsed_bundle)
                        for count, parsed_bundle in enumerate(self.bundles_parsed)]
             concurrent.futures.wait(futures)


### PR DESCRIPTION
Indexing with elasticsearch gets overwhelmed with more than ~5 worker threads going simultaneously. This limits the amount to 5.

┆Issue is synchronized with this [JIRA Task](https://ucsc-cgl.atlassian.net/browse/LOAD-57)
┆Project Name: CGP-Data Loader
┆Issue Number: LOAD-57
